### PR TITLE
New Fixes

### DIFF
--- a/bin/oas3-to-raml.js
+++ b/bin/oas3-to-raml.js
@@ -6,7 +6,7 @@ const version = require('../package.json').version;
 
 // Import converters
 const { convertFromOas3ToOas2, convertFromOas2ToRaml } = require('../lib/converters');
-const { fixNullables, fixExtendedTypes, fixExamples } = require('../lib/raml-fixers');
+const { fixNullables, fixExtendedTypes, fixExamples, fixFormatType} = require('../lib/raml-fixers');
 
 // Conversion steps, each step contains:
 // * desc: Descriptive summary of step (e.g. 'converting from X to Y')
@@ -16,7 +16,8 @@ const steps = [
   { desc: 'Convert from OpenAPI 2.0 to RAML', action: convertFromOas2ToRaml },
   { desc: 'Fix \'nullable\' types', action: fixNullables },
   { desc: 'Fix extended types', action: fixExtendedTypes },
-  { desc: 'Fix numeric examples', action: fixExamples }
+  { desc: 'Fix numeric examples', action: fixExamples },
+  { desc: 'Fix format type', action: fixFormatType }
 ];
 
 /**

--- a/lib/raml-fixers/example-fixer.js
+++ b/lib/raml-fixers/example-fixer.js
@@ -18,13 +18,16 @@ const _ = require('lodash');
 
 function customizer (input) {
   if (!_.isPlainObject(input) || input.example == null ||
-        isNaN(input.example) || input.type !== 'string') {
+        isNaN(input.example) || (input.type !== 'string' && input.type != null) ) {
     // Let caller handle cloning
     return;
   }
 
   const output = _.cloneDeep(input);
   output.example = output.example.toString();
+  if (output.type == null) {
+    output.type = 'string'
+  }
   return output;
 }
 

--- a/lib/raml-fixers/format-type-fixer.js
+++ b/lib/raml-fixers/format-type-fixer.js
@@ -1,0 +1,35 @@
+const _ = require('lodash');
+
+/**
+ *  Fix string examples that have unquoted numbers, for example:
+ *
+ *  properties:
+ *    name: E-mail
+ *    type: string
+ *    format: email
+ *
+ *  -- converts to --
+ *
+ *  properties:
+ *    name: E-mail
+ *    type: string
+ *    (oas-format): email
+ */
+
+function customizer (input) {
+  if (!_.isPlainObject(input) || input.format == null) {
+    // Let caller handle cloning
+    return;
+  }
+
+  const output = _.clone(input);
+  output['(oas-format)'] = output.format;
+  delete output.format;
+  return output;
+}
+
+function fixFormatType (input) {
+  return _.cloneDeepWith(input, customizer);
+}
+
+module.exports = fixFormatType;

--- a/lib/raml-fixers/index.js
+++ b/lib/raml-fixers/index.js
@@ -7,6 +7,7 @@ const yaml = require('js-yaml');
 const fixNullables = require('./nullable-fixer');
 const fixExtendedTypes = require('./extended-type-fixer');
 const fixExamples = require('./example-fixer');
+const fixFormatType = require('./format-type-fixer');
 
 /**
  * Transform input using specified function
@@ -22,5 +23,6 @@ function transform (ramlTransformer, input) {
 module.exports = {
   fixNullables:     (input) => transform(fixNullables, input),
   fixExtendedTypes: (input) => transform(fixExtendedTypes, input),
-  fixExamples:      (input) => transform(fixExamples, input)
+  fixExamples:      (input) => transform(fixExamples, input),
+  fixFormatType:    (input) => transform(fixFormatType, input)
 };


### PR DESCRIPTION
- Added a new criteria to convert examples to string. It is in the case of a number which have no type (p.e. phone number).

- Converted format field (not allowed in RAML 1.0) to (oas-format).