### PR TITLE
EECO-1761: Increment package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oas3-to-raml",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OpenAPI 3.0 to RAML converter",
   "bin": {
     "oas3-to-raml": "./bin/oas3-to-raml.js"


### PR DESCRIPTION
Increment package version to 1.0.3 to remove some accidentally published
files to npmjs and reduce the package size